### PR TITLE
#163470713 Get all Political Parties

### DIFF
--- a/server/controllers/party.controllers.js
+++ b/server/controllers/party.controllers.js
@@ -1,0 +1,10 @@
+const controllers = {
+  getAllParties(req, res) {
+    res.status(200).json({
+      status: 200,
+      data: req.data,
+    });
+  },
+};
+
+export default controllers;

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 import '@babel/polyfill';
 import express from 'express';
 import officeRoutes from './routes/office.routes';
+import partyRoutes from './routes/party.routes';
 
 const app = express();
 
@@ -12,6 +13,7 @@ app.get('/', (req, res) => {
 });
 
 app.use('/api/v1', officeRoutes);
+app.use('/api/v1', partyRoutes);
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {

--- a/server/middleware/party.middleware.js
+++ b/server/middleware/party.middleware.js
@@ -1,0 +1,12 @@
+import db from '../database/mockdata';
+
+const { parties } = db;
+
+const middleware = {
+  getAllParties(req, res, next) {
+    req.data = parties;
+    next();
+  },
+};
+
+export default middleware;

--- a/server/routes/party.routes.js
+++ b/server/routes/party.routes.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import middleware from '../middleware/party.middleware';
+import controllers from '../controllers/party.controllers';
+
+
+const router = express.Router();
+
+router.get('/parties',
+  middleware.getAllParties,
+  controllers.getAllParties);
+
+export default router;

--- a/test/party.test.js
+++ b/test/party.test.js
@@ -1,0 +1,24 @@
+/* eslint-disable no-undef */
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../server/index';
+
+
+chai.use(chaiHttp);
+
+describe('Get all parties', () => {
+  it('should respond with all parties', (done) => {
+    chai.request(app)
+      .get('/api/v1/parties')
+      .end((err, res) => {
+        const { status, data } = res.body;
+        expect(status).to.equal(200);
+        if (data.length) {
+          expect(data[0]).to.have.property('id');
+          expect(data[0]).to.have.property('name');
+          expect(data[0]).to.have.property('logoUrl');
+        }
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Get all political parties when a `GET` request is sent to `api/v1/parties`

#### Description of task to be completed?
Have this endpoint working `GET api/v1/parties`

#### How this PR can be tested
- After cloning this repo, cd into it and switch to branch
`git checkout ft-get-parties-163470713 `

- run `npm run dev` to start server or `npm test` to test the endpoint

- Using Postman, test the above endpoint

#### What are the relevant pivotal tracker stories?
[#163470713](https://www.pivotaltracker.com/story/show/163470713)

#### Screenshots
- get all political parties
![get all parties](https://user-images.githubusercontent.com/32283335/51748587-30b35180-20ad-11e9-82fc-978cd9c371f4.PNG)
