### PR TITLE
##4209149 Build out CRUD endpoints for Political Parties

### DIFF
--- a/server/controllers/party.controllers.js
+++ b/server/controllers/party.controllers.js
@@ -5,6 +5,36 @@ const controllers = {
       data: req.data,
     });
   },
+
+  getPartiesById(req, res) {
+    res.status(200).json({
+      status: 200,
+      data: [req.data],
+    });
+  },
+
+  editParties(req, res) {
+    res.status(200).json({
+      status: 200,
+      data: [req.data],
+    });
+  },
+
+  deleteParties(req, res) {
+    res.status(200).json({
+      status: 200,
+      data: [req.data],
+      message: `${req.data.name} deleted successfully`,
+    });
+  },
+
+  createParties(req, res) {
+    res.status(200).json({
+      status: 201,
+      data: [req.data],
+      message: 'party created successfully',
+    });
+  },
 };
 
 export default controllers;

--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ const app = express();
 
 // middlewares
 app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 app.get('/', (req, res) => {
   res.send('Welcome to the politico API');
@@ -14,6 +15,12 @@ app.get('/', (req, res) => {
 
 app.use('/api/v1', officeRoutes);
 app.use('/api/v1', partyRoutes);
+
+
+// invalid routes
+app.use((req, res) => {
+  res.status(404).json({ error: 'check documentation on routes' });
+});
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {

--- a/server/middleware/party.middleware.js
+++ b/server/middleware/party.middleware.js
@@ -7,6 +7,110 @@ const middleware = {
     req.data = parties;
     next();
   },
+  getPartiesById(req, res, next) {
+    const id = parseFloat(req.params.id);
+    if (isNaN(id)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'id must be a number',
+      });
+    }
+
+    const party = parties.find(item => item.id === id);
+
+    if (!party) {
+      return res.status(404).json({
+        status: 404,
+        error: 'party not found',
+      });
+    }
+
+    req.data = party;
+    return next();
+  },
+
+  editParties(req, res, next) {
+    const id = parseFloat(req.params.id);
+    const { name } = req.body;
+    if (!name || !name.trim()) {
+      return res.status(400).json({
+        status: 400,
+        error: 'name must be present',
+      });
+    }
+
+    if (isNaN(id)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'id must be a number',
+      });
+    }
+
+    const newPartyName = parties.find(party => party.id === id);
+
+    if (!newPartyName) {
+      return res.status(404).json({
+        status: 404,
+        error: 'party not found',
+      });
+    }
+    newPartyName.name = name;
+    req.data = newPartyName;
+    return next();
+  },
+
+  deleteParty(req, res, next) {
+    const id = parseFloat(req.params.id);
+    if (isNaN(id)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'id must be a number',
+      });
+    }
+
+    const deletedParty = parties.find((party, i) => {
+      if (party.id === id) {
+        return parties.splice(i, 1);
+      }
+
+      return undefined;
+    });
+
+    if (!deletedParty) {
+      return res.status(404).json({
+        status: 404,
+        error: 'party not found',
+      });
+    }
+
+    req.data = deletedParty;
+    return next();
+  },
+
+  createParties(req, res, next) {
+    const partyName = req.body.name.toLowerCase();
+
+    const presentParty = parties.find(party => party.name.toLowerCase() === partyName);
+    if (presentParty) {
+      return res.status(409).json({
+        status: 409,
+        error: 'party already present',
+      });
+    }
+
+
+    const newId = parties[parties.length - 1].id + 1;
+    const newParty = {
+      id: newId,
+      name: req.body.name,
+      hqAddress: req.body.hqAddress,
+      logoUrl: req.body.logoUrl,
+    };
+
+    parties.push(newParty);
+    req.data = newParty;
+    return next();
+  },
 };
 
 export default middleware;

--- a/server/middleware/party.validation.js
+++ b/server/middleware/party.validation.js
@@ -1,0 +1,37 @@
+const validateParty = (req, res, next) => {
+  let verified = true;
+  const error = [];
+
+  const { name, hqAddress, logoUrl } = req.body;
+
+  if (!name || !name.trim()) {
+    verified = false;
+    error.push({ name: 'name must be present' });
+  }
+
+  if (!hqAddress || !hqAddress.trim()) {
+    verified = false;
+    error.push({ hqAddress: 'hqAddress must be present' });
+  }
+
+  if (logoUrl) {
+    if ((!(/\.(gif|jpg|jpeg|tiff|png)$/i).test(logoUrl))) {
+      verified = false;
+      error.push({ logoUrl: 'invalid format' });
+    }
+  } else {
+    verified = false;
+    error.push({ logoUrl: 'logo must be present' });
+  }
+
+  if (!verified) {
+    return res.status(400).json({
+      status: 400,
+      error,
+    });
+  }
+
+  return next();
+};
+
+export default validateParty;

--- a/server/routes/party.routes.js
+++ b/server/routes/party.routes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import middleware from '../middleware/party.middleware';
 import controllers from '../controllers/party.controllers';
+import validateParty from '../middleware/party.validation';
 
 
 const router = express.Router();
@@ -8,5 +9,23 @@ const router = express.Router();
 router.get('/parties',
   middleware.getAllParties,
   controllers.getAllParties);
+
+router.get('/parties/:id',
+  middleware.getPartiesById,
+  controllers.getPartiesById);
+
+router.patch('/parties/:id/name',
+  middleware.editParties,
+  controllers.editParties);
+
+router.delete('/parties/:id',
+  middleware.deleteParty,
+  controllers.deleteParties);
+
+router.post('/parties',
+  validateParty,
+  middleware.createParties,
+  controllers.createParties);
+
 
 export default router;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,4 +16,24 @@ describe('Homepage', () => {
         done();
       });
   });
+
+  it('should respond with error: invalid routes', (done) => {
+    chai.request(app)
+      .get('/api/v1/party')
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body.error).to.equal('check documentation on routes');
+        done();
+      });
+  });
+
+  it('should respond with error: invalid routes', (done) => {
+    chai.request(app)
+      .get('/api/v1/office')
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body.error).to.equal('check documentation on routes');
+        done();
+      });
+  });
 });

--- a/test/party.test.js
+++ b/test/party.test.js
@@ -22,3 +22,252 @@ describe('Get all parties', () => {
       });
   });
 });
+
+describe('Get a specific party', () => {
+  it('should respond with a specific party', (done) => {
+    chai.request(app)
+      .get('/api/v1/parties/1')
+      .end((err, res) => {
+        const { status, data } = res.body;
+        expect(status).to.equal(200);
+        expect(data[0]).to.have.property('id');
+        expect(data[0]).to.have.property('name');
+        expect(data[0]).to.have.property('logoUrl');
+        expect(data[0].id).to.equal(1);
+        done();
+      });
+  });
+
+  it('should not respond with a specific party: party not found', (done) => {
+    chai.request(app)
+      .get('/api/v1/parties/0')
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(404);
+        expect(error).to.equal('party not found');
+        done();
+      });
+  });
+
+  it('should not respond with a specific party: id is not number', (done) => {
+    chai.request(app)
+      .get('/api/v1/parties/a')
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error).to.equal('id must be a number');
+        done();
+      });
+  });
+});
+
+describe('Edit a party name', () => {
+  it('should respond with the edited party name', (done) => {
+    chai.request(app)
+      .patch('/api/v1/parties/1/name')
+      .send(
+        {
+          name: 'PDP',
+        },
+      )
+      .end((err, res) => {
+        const { status, data } = res.body;
+        expect(status).to.equal(200);
+        expect(data[0]).to.have.property('id');
+        expect(data[0]).to.have.property('name');
+        expect(data[0]).to.have.property('logoUrl');
+        expect(data[0].id).to.equal(1);
+        expect(data[0].name).to.equal('PDP');
+        done();
+      });
+  });
+
+  it('should not respond with the edited party name: id is not a number', (done) => {
+    chai.request(app)
+      .patch('/api/v1/parties/a/name')
+      .send(
+        {
+          name: 'PDP',
+        },
+      )
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error).to.equal('id must be a number');
+        done();
+      });
+  });
+
+  it('should not respond with the edited party name: party not found', (done) => {
+    chai.request(app)
+      .patch('/api/v1/parties/0/name')
+      .send(
+        {
+          name: 'PDP',
+        },
+      )
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(404);
+        expect(error).to.equal('party not found');
+        done();
+      });
+  });
+
+  it('should not respond with the edited party name: name not present', (done) => {
+    chai.request(app)
+      .patch('/api/v1/parties/0/name')
+      .send({})
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error).to.equal('name must be present');
+        done();
+      });
+  });
+});
+
+describe('Delete a party', () => {
+  it('should respond with a the deleted party and a message', (done) => {
+    chai.request(app)
+      .delete('/api/v1/parties/2')
+      .end((err, res) => {
+        const { status, data, message } = res.body;
+        expect(status).to.equal(200);
+        expect(data[0]).to.have.property('id');
+        expect(data[0]).to.have.property('name');
+        expect(data[0]).to.have.property('logoUrl');
+        expect(data[0].id).to.equal(2);
+        expect(message).to.equal(`${data[0].name} deleted successfully`);
+        done();
+      });
+  });
+
+  it('should not respond with a deleted party: party not found', (done) => {
+    chai.request(app)
+      .delete('/api/v1/parties/0')
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(404);
+        expect(error).to.equal('party not found');
+        done();
+      });
+  });
+
+  it('should not respond with a specific party: id is not number', (done) => {
+    chai.request(app)
+      .delete('/api/v1/parties/a')
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error).to.equal('id must be a number');
+        done();
+      });
+  });
+});
+
+describe('Create political party', () => {
+  it('should respond with the created party', (done) => {
+    chai.request(app)
+      .post('/api/v1/parties')
+      .send({
+        name: 'CPC',
+        hqAddress: 'Lagos',
+        logoUrl: 'logourl.png',
+      })
+      .end((err, res) => {
+        const { status, data, message } = res.body;
+        const { name, hqAddress, logoUrl } = data[0];
+        expect(status).to.equal(201);
+        expect(data[0]).to.have.property('id');
+        expect(data[0]).to.have.property('name');
+        expect(data[0]).to.have.property('hqAddress');
+        expect(data[0]).to.have.property('logoUrl');
+        expect(name).to.equal('CPC');
+        expect(hqAddress).to.equal('Lagos');
+        expect(logoUrl).to.equal('logourl.png');
+        expect(message).to.equal('party created successfully');
+        done();
+      });
+  });
+
+  it('should not respond with the created party: no name', (done) => {
+    chai.request(app)
+      .post('/api/v1/parties')
+      .send({
+        name: '',
+        hqAddress: 'Lagos',
+        logo: 'logourl.jpeg',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error[0].name).to.equal('name must be present');
+        done();
+      });
+  });
+
+  it('should not respond with the created party: no hqAddress', (done) => {
+    chai.request(app)
+      .post('/api/v1/parties')
+      .send({
+        name: 'CPC',
+        hqAddress: '',
+        logo: 'logourl.jpg',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error[0].hqAddress).to.equal('hqAddress must be present');
+        done();
+      });
+  });
+
+  it('should not respond with the created party: no logo', (done) => {
+    chai.request(app)
+      .post('/api/v1/parties')
+      .send({
+        name: 'CPC',
+        hqAddress: 'Lagos',
+        logoUrl: '',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error[0].logoUrl).to.equal('logo must be present');
+        done();
+      });
+  });
+
+  it('should not respond with the created party: invalid logo format', (done) => {
+    chai.request(app)
+      .post('/api/v1/parties')
+      .send({
+        name: 'CPC',
+        hqAddress: 'Lagos',
+        logoUrl: 'logourl',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error[0].logoUrl).to.equal('invalid format');
+        done();
+      });
+  });
+
+  it('should not respond with the created party: party already exist', (done) => {
+    chai.request(app)
+      .post('/api/v1/parties')
+      .send({
+        name: 'YBNB',
+        hqAddress: 'Lagos',
+        logoUrl: 'logourl.png',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(409);
+        expect(error).to.equal('party already present');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Have CRUD api endpoints for political parties built out

#### Description of Task to be completed?
Have the following endpoints working:
- create endpoint to get a specific political party
`GET /api/v1/parties/:id`

- create endpoint to edit a political party name
`PATCH /api/v1/parties/:id/name`

- create endpoint to delete political party
`DELETE /api/v1/parties/:id`

- create endpoint to create a political party
`POST /api/v1/parties`

#### How should this be manually tested?
- After cloning this repo, switch to branch
`git checkout ft-build-parties-api-4209149`

- run `npm test` to see test cases and results

- run `npm run dev` and test the above endpoints using Postman

see below for screenshots

#### Any background context you want to provide?
There is an already built out feature to get all political parties

#### What are the relevant pivotal tracker stories?
- get a specific political party: [#163470679](https://www.pivotaltracker.com/story/show/163470679l)
- edit a political party name: [#163470688](https://www.pivotaltracker.com/story/show/163470688)
- delete political party: [#163470696](https://www.pivotaltracker.com/story/show/163470696)
- create a political party: [#163470487](https://www.pivotaltracker.com/story/show/163470487)
- build endpoints: [##4209149](https://www.pivotaltracker.com/epic/show/4209149)

#### Screenshots
- get a specific political party:
![get a specific party](https://user-images.githubusercontent.com/32283335/51762557-60c01c00-20d0-11e9-80cb-5569e6879811.PNG)

- edit a political party name:
![editparty](https://user-images.githubusercontent.com/32283335/51762596-733a5580-20d0-11e9-8d5d-978b6ca2d534.PNG)

- delete political party:
![delete parties](https://user-images.githubusercontent.com/32283335/51762617-82210800-20d0-11e9-866c-b5e33c690e0f.PNG)

- create a political party:
![create party](https://user-images.githubusercontent.com/32283335/51762807-0e332f80-20d1-11e9-88fe-7473e19b08e7.PNG)

