### PR TITLE
##4209399 Build out CRUD api endpoint for political offices

### DIFF
--- a/server/controllers/office.controllers.js
+++ b/server/controllers/office.controllers.js
@@ -5,6 +5,21 @@ const controllers = {
       data: req.data,
     });
   },
+
+  getOfficeById(req, res) {
+    res.status(200).json({
+      status: 200,
+      data: [req.data],
+    });
+  },
+
+  creatOffice(req, res) {
+    res.status(201).json({
+      status: 201,
+      data: [req.data],
+      message: 'office created successfully',
+    });
+  },
 };
 
 export default controllers;

--- a/server/database/mockdata.js
+++ b/server/database/mockdata.js
@@ -38,12 +38,12 @@ const offices = [
     name: 'President',
   },
   {
-    id: 1,
+    id: 2,
     type: 'State',
     name: 'Governor',
   },
   {
-    id: 1,
+    id: 3,
     type: 'Local',
     name: 'Chairman',
   },

--- a/server/middleware/office.middleware.js
+++ b/server/middleware/office.middleware.js
@@ -2,12 +2,57 @@ import db from '../database/mockdata';
 
 const { offices } = db;
 
-const middlewares = {
+
+const middleware = {
   getAllOffices(req, res, next) {
     req.data = offices;
     next();
   },
 
+  getOfficesById(req, res, next) {
+    const id = parseFloat(req.params.id);
+    if (isNaN(id)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'id must be a number',
+      });
+    }
+
+    const office = offices.find(item => item.id === id);
+
+    if (!office) {
+      return res.status(404).json({
+        status: 404,
+        error: 'office not found',
+      });
+    }
+
+    req.data = office;
+    return next();
+  },
+
+  createOffice(req, res, next) {
+    const officeName = req.body.name.toLowerCase();
+
+    const presentOffice = offices.find(office => office.name.toLowerCase() === officeName);
+    if (presentOffice) {
+      return res.status(409).json({
+        status: 409,
+        error: 'office already present',
+      });
+    }
+
+    const newId = offices[offices.length - 1].id + 1;
+    const newOffice = {
+      id: newId,
+      name: req.body.name,
+      type: req.body.type,
+    };
+
+    offices.push(newOffice);
+    req.data = newOffice;
+    return next();
+  },
 };
 
-export default middlewares;
+export default middleware;

--- a/server/middleware/office.validation.js
+++ b/server/middleware/office.validation.js
@@ -1,0 +1,43 @@
+const validateOffice = (req, res, next) => {
+  let verified = true;
+  const error = [];
+
+  const { type, name } = req.body;
+  const typesOfGov = ['Federal', 'State', 'Local', 'Legislative'];
+
+  if (!type || !type.trim()) {
+    verified = false;
+    error.push({ type: 'type must be present' });
+  }
+
+  if (!typesOfGov.includes(type)) {
+    verified = false;
+    error.push({ type: 'please specify a valid type: Federal, State, Local or Legislative' });
+  }
+
+  if (!name || !name.trim()) {
+    verified = false;
+    error.push({ name: 'name must be present' });
+  }
+
+  if (!isNaN(parseFloat(name))) {
+    verified = false;
+    error.push({ name: 'name should not be only numbers' });
+  }
+
+  if (!isNaN(parseFloat(type))) {
+    verified = false;
+    error.push({ type: 'type should not be only numbers' });
+  }
+
+  if (!verified) {
+    return res.status(400).json({
+      status: 400,
+      error,
+    });
+  }
+
+  return next();
+};
+
+export default validateOffice;

--- a/server/middleware/party.validation.js
+++ b/server/middleware/party.validation.js
@@ -24,6 +24,17 @@ const validateParty = (req, res, next) => {
     error.push({ logoUrl: 'logo must be present' });
   }
 
+  if (!isNaN(parseFloat(name))) {
+    verified = false;
+    error.push({ name: 'name should not be only numbers' });
+  }
+
+  if (!isNaN(parseFloat(hqAddress))) {
+    verified = false;
+    error.push({ hqAddress: 'hqAddress should not be only numbers' });
+  }
+
+
   if (!verified) {
     return res.status(400).json({
       status: 400,

--- a/server/routes/office.routes.js
+++ b/server/routes/office.routes.js
@@ -1,12 +1,22 @@
 import express from 'express';
-import middleware from '../middleware/office.middleware';
-import controllers from '../controllers/office.controllers';
+import officeMiddleware from '../middleware/office.middleware';
+import officeControllers from '../controllers/office.controllers';
+import officeValidation from '../middleware/office.validation';
 
 const router = express.Router();
 
 // offices
 router.get('/offices',
-  middleware.getAllOffices,
-  controllers.getAllOffices);
+  officeMiddleware.getAllOffices,
+  officeControllers.getAllOffices);
+
+router.get('/offices/:id',
+  officeMiddleware.getOfficesById,
+  officeControllers.getOfficeById);
+
+router.post('/offices',
+  officeValidation,
+  officeMiddleware.createOffice,
+  officeControllers.creatOffice);
 
 export default router;

--- a/test/office.test.js
+++ b/test/office.test.js
@@ -23,3 +23,155 @@ describe('Get all offices', () => {
       });
   });
 });
+
+describe('Get a specific office', () => {
+  it('should respond with a specific office', (done) => {
+    chai.request(app)
+      .get('/api/v1/offices/1')
+      .end((err, res) => {
+        const { status, data } = res.body;
+        expect(status).to.equal(200);
+        expect(data[0]).to.have.property('id');
+        expect(data[0]).to.have.property('type');
+        expect(data[0]).to.have.property('name');
+        expect(data[0].id).to.equal(1);
+        done();
+      });
+  });
+
+  it('should not respond with a specific office: office not found', (done) => {
+    chai.request(app)
+      .get('/api/v1/offices/0')
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(404);
+        expect(error).to.equal('office not found');
+        done();
+      });
+  });
+
+  it('should not respond with a specific office: id is not number', (done) => {
+    chai.request(app)
+      .get('/api/v1/offices/a')
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error).to.equal('id must be a number');
+        done();
+      });
+  });
+});
+
+describe('Create office', () => {
+  it('should respond with the created office', (done) => {
+    chai.request(app)
+      .post('/api/v1/offices')
+      .send({
+        name: 'Senate',
+        type: 'Federal',
+      })
+      .end((err, res) => {
+        const { status, data, message } = res.body;
+        const { name, type } = data[0];
+        expect(status).to.equal(201);
+        expect(data[0]).to.have.property('id');
+        expect(data[0]).to.have.property('name');
+        expect(data[0]).to.have.property('type');
+        expect(name).to.equal('Senate');
+        expect(type).to.equal('Federal');
+        expect(message).to.equal('office created successfully');
+        done();
+      });
+  });
+
+  it('should not respond with the created office: no name', (done) => {
+    chai.request(app)
+      .post('/api/v1/offices')
+      .send({
+        name: '',
+        type: 'Federal',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error[0].name).to.equal('name must be present');
+        done();
+      });
+  });
+
+  it('should not respond with the created office: no type', (done) => {
+    chai.request(app)
+      .post('/api/v1/offices')
+      .send({
+        name: 'Senate',
+        type: '',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error[0].type).to.equal('type must be present');
+        done();
+      });
+  });
+
+  it('should not respond with the created office: name is number', (done) => {
+    chai.request(app)
+      .post('/api/v1/offices')
+      .send({
+        name: '1',
+        type: 'Federal',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error[0].name).to.equal('name should not be only numbers');
+        done();
+      });
+  });
+
+  it('should not respond with the created office: type is number', (done) => {
+    chai.request(app)
+      .post('/api/v1/offices')
+      .send({
+        name: 'President',
+        type: '1',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error[1].type).to.equal('type should not be only numbers');
+        done();
+      });
+  });
+
+
+  it('should not respond with the created office: wrong type', (done) => {
+    chai.request(app)
+      .post('/api/v1/offices')
+      .send({
+        name: 'Senate',
+        type: 'Mayor',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error[0].type).to.equal('please specify a valid type: Federal, State, Local or Legislative');
+        done();
+      });
+  });
+
+  it('should not respond with the created office: office already exist', (done) => {
+    chai.request(app)
+      .post('/api/v1/offices')
+      .send({
+        name: 'President',
+        type: 'Federal',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(409);
+        expect(error).to.equal('office already present');
+        done();
+      });
+  });
+});

--- a/test/party.test.js
+++ b/test/party.test.js
@@ -223,6 +223,38 @@ describe('Create political party', () => {
       });
   });
 
+  it('should not respond with the created party: name is number', (done) => {
+    chai.request(app)
+      .post('/api/v1/parties')
+      .send({
+        name: '1',
+        hqAddress: 'Lagos',
+        logoUrl: 'logourl.jpg',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error[0].name).to.equal('name should not be only numbers');
+        done();
+      });
+  });
+
+  it('should not respond with the created party: hqAddress is number', (done) => {
+    chai.request(app)
+      .post('/api/v1/parties')
+      .send({
+        name: 'PCPEP',
+        hqAddress: '1',
+        logoUrl: 'logourl.jpg',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status).to.equal(400);
+        expect(error[0].hqAddress).to.equal('hqAddress should not be only numbers');
+        done();
+      });
+  });
+
   it('should not respond with the created party: no logo', (done) => {
     chai.request(app)
       .post('/api/v1/parties')


### PR DESCRIPTION
#### What does this PR do?
Have CRUD api endpoints for political offices built out

#### Description of Task to be completed?
Have the following endpoints working:
- create endpoint to get specific office
`GET api/v1/offices/:id`

- create endpoint to create office
`POST api/v1/offices`

#### How should this be manually tested?
- After cloning this repo, switch to branch
`git checkout ft-build-offices-api-4209399`

- run `npm test` to see test cases and results

- run `npm run dev` and test the above endpoints using Postman

#### Any background context you want to provide?
There is an already built out feature to get all political office raised as a PR

#### What are the relevant pivotal tracker stories?
- create endpoint to get specific office: [#163470665](https://www.pivotaltracker.com/story/show/163470665)

- create endpoint to create office: [#163470702](https://www.pivotaltracker.com/story/show/163470702)

#### Screenshots
- get specific office:
![get a specific office](https://user-images.githubusercontent.com/32283335/51779923-c3360e00-210a-11e9-91d6-4167a1bb3f46.PNG)

- create office:
![create office](https://user-images.githubusercontent.com/32283335/51779977-190ab600-210b-11e9-8eb0-b32f9afeed11.PNG)


