### PR TITLE
#163648726 Data types input

### DIFF
--- a/server/helper/auth.helper.js
+++ b/server/helper/auth.helper.js
@@ -41,6 +41,26 @@ const bodyIsString = (req, res, next) => {
   return next();
 };
 
+const bodyIsNumber = (req, res, next) => {
+  const data = Object.entries(req.body);
+  let verified = true;
+  const error = [];
+  data.forEach((item) => {
+    if (typeof item[1] !== 'number') {
+      verified = false;
+      error.push({ error: `${item[0]} must be a number` });
+    }
+  });
+
+  if (!verified) {
+    return res.status(400).json({
+      status: 400,
+      error,
+    });
+  }
+  return next();
+};
+
 const checkParams = (req, res, next) => {
   const { id } = req.params;
   if (id.trim().length) {
@@ -66,4 +86,5 @@ export default {
   isAdmin,
   bodyIsString,
   checkParams,
+  bodyIsNumber,
 };

--- a/server/middleware/office.middleware.js
+++ b/server/middleware/office.middleware.js
@@ -6,6 +6,21 @@ const middleware = {
   async registerCandidate(req, res, next) {
     const userId = parseFloat(req.params.id);
 
+    const { office: officeID, party: partyID } = req.body;
+    if (!officeID) {
+      return res.status(400).json({
+        status: 400,
+        error: 'office must be present',
+      });
+    }
+
+    if (!partyID) {
+      return res.status(400).json({
+        status: 400,
+        error: 'party must be present',
+      });
+    }
+
     const { rows: office } = await db(queries.selectOfficeById(req.body.office));
     const { rows: party } = await db(queries.selectPartyById(req.body.party));
 

--- a/server/middleware/votes.middleware.js
+++ b/server/middleware/votes.middleware.js
@@ -4,14 +4,14 @@ import queries from '../database/queries.db';
 const middleware = {
   async validateVotes(req, res, next) {
     const { candidate, office } = req.body;
-    if (!candidate || !candidate.trim()) {
+    if (!candidate) {
       return res.status(400).json({
         status: 400,
         error: 'candidate must be present',
       });
     }
 
-    if (!office || !office.trim()) {
+    if (!office) {
       return res.status(400).json({
         status: 400,
         error: 'office must be present',

--- a/server/routes/office.routes.js
+++ b/server/routes/office.routes.js
@@ -34,7 +34,7 @@ router.post('/office/:id/register',
   authMiddleware.verifyToken,
   authHelper.isAdmin,
   authHelper.checkParams,
-  authHelper.bodyIsString,
+  authHelper.bodyIsNumber,
   officeMiddleware.registerCandidate,
   officeControllers.registerCandidate);
 

--- a/server/routes/votes.routes.js
+++ b/server/routes/votes.routes.js
@@ -10,7 +10,7 @@ const router = express.Router();
 
 router.post('/votes',
   authMiddleware.verifyToken,
-  authHelpers.bodyIsString,
+  authHelpers.bodyIsNumber,
   voteMiddleware.validateVotes,
   voteMiddleware.createVotes,
   voteControllers.voteCandidate);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,7 +6,7 @@ import app from '../server/index';
 
 chai.use(chaiHttp);
 
-describe('Homepage', () => {
+describe('HOMEPAGE', () => {
   it('should respond with welcome title', (done) => {
     chai.request(app)
       .get('/')

--- a/test/office.test.js
+++ b/test/office.test.js
@@ -37,7 +37,7 @@ before('login user', (done) => {
 });
 
 
-describe('Get all offices', () => {
+describe('GET ALL OFFICES', () => {
   it('should respond with all offices', (done) => {
     chai.request(app)
       .get('/api/v1/offices')
@@ -55,7 +55,7 @@ describe('Get all offices', () => {
   });
 });
 
-describe('Get a specific office', () => {
+describe('GET A SPECIFIC OFFICE', () => {
   it('should respond with a specific office', (done) => {
     chai.request(app)
       .get('/api/v1/offices/1')
@@ -96,7 +96,7 @@ describe('Get a specific office', () => {
   });
 });
 
-describe('Create office', () => {
+describe('CREATE OFFICE', () => {
   it('should respond with the created office', (done) => {
     chai.request(app)
       .post('/api/v1/offices')
@@ -237,8 +237,8 @@ describe('CREATE CANDIDATE', () => {
       .post('/api/v1/office/6/register')
       .set('Authorization', adminToken)
       .send({
-        office: '1',
-        party: '4',
+        office: 1,
+        party: 4,
       })
       .end((err, res) => {
         expect(res).to.have.status(201);
@@ -253,8 +253,8 @@ describe('CREATE CANDIDATE', () => {
     chai.request(app)
       .post('/api/v1/office/5/register')
       .send({
-        office: '1',
-        party: '1',
+        office: 1,
+        party: 1,
       })
       .end((err, res) => {
         expect(res).to.have.status(403);
@@ -269,8 +269,8 @@ describe('CREATE CANDIDATE', () => {
       .post('/api/v1/office/5/register')
       .set('Authorization', 'this is not a token')
       .send({
-        office: '1',
-        party: '1',
+        office: 1,
+        party: 1,
       })
       .end((err, res) => {
         expect(res).to.have.status(403);
@@ -285,8 +285,8 @@ describe('CREATE CANDIDATE', () => {
       .post('/api/v1/office/5/register')
       .set('Authorization', userToken)
       .send({
-        office: '1',
-        party: '1',
+        office: 1,
+        party: 1,
       })
       .end((err, res) => {
         expect(res).to.have.status(401);
@@ -301,8 +301,8 @@ describe('CREATE CANDIDATE', () => {
       .post('/api/v1/office/5/register')
       .set('Authorization', adminToken)
       .send({
-        office: '0',
-        party: '1',
+        office: 1000,
+        party: 1,
       })
       .end((err, res) => {
         expect(res).to.have.status(404);
@@ -317,8 +317,8 @@ describe('CREATE CANDIDATE', () => {
       .post('/api/v1/office/5/register')
       .set('Authorization', adminToken)
       .send({
-        office: '1',
-        party: '0',
+        office: 1,
+        party: 1000,
       })
       .end((err, res) => {
         expect(res).to.have.status(404);
@@ -333,8 +333,8 @@ describe('CREATE CANDIDATE', () => {
       .post('/api/v1/office/2/register')
       .set('Authorization', adminToken)
       .send({
-        office: '1',
-        party: '1',
+        office: 1,
+        party: 1,
       })
       .end((err, res) => {
         expect(res).to.have.status(409);
@@ -344,13 +344,43 @@ describe('CREATE CANDIDATE', () => {
       });
   });
 
+  it('should return not return created candidate: no office', (done) => {
+    chai.request(app)
+      .post('/api/v1/office/5/register')
+      .set('Authorization', adminToken)
+      .send({
+        party: 1,
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error).to.have.equal('office must be present');
+        done();
+      });
+  });
+
+  it('should return not return created candidate: no party', (done) => {
+    chai.request(app)
+      .post('/api/v1/office/5/register')
+      .set('Authorization', adminToken)
+      .send({
+        office: 1,
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error).to.have.equal('party must be present');
+        done();
+      });
+  });
+
   it('should return not return created candidate: id is not present', (done) => {
     chai.request(app)
       .post('/api/v1/office/ /register')
       .set('Authorization', adminToken)
       .send({
-        office: '1',
-        party: '1',
+        office: 1,
+        party: 1,
       })
       .end((err, res) => {
         expect(res).to.have.status(400);
@@ -365,13 +395,29 @@ describe('CREATE CANDIDATE', () => {
       .post('/api/v1/office/a/register')
       .set('Authorization', adminToken)
       .send({
+        office: 1,
+        party: 1,
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error).to.have.equal('id must be a number');
+        done();
+      });
+  });
+
+  it('should return not return created candidate: body is string', (done) => {
+    chai.request(app)
+      .post('/api/v1/office/6/register')
+      .set('Authorization', adminToken)
+      .send({
         office: '1',
         party: '1',
       })
       .end((err, res) => {
         expect(res).to.have.status(400);
         expect(res.body.status).to.equal(400);
-        expect(res.body.error).to.have.equal('id must be a number');
+        expect(res.body.error[0]).to.have.property('error');
         done();
       });
   });

--- a/test/party.test.js
+++ b/test/party.test.js
@@ -35,7 +35,7 @@ before('login user', (done) => {
     });
 });
 
-describe('Get all parties', () => {
+describe('GET ALL PARTIES', () => {
   it('should respond with all parties', (done) => {
     chai.request(app)
       .get('/api/v1/parties')
@@ -53,7 +53,7 @@ describe('Get all parties', () => {
   });
 });
 
-describe('Get a specific party', () => {
+describe('GET A SPECIFIC PARTY', () => {
   it('should respond with a specific party', (done) => {
     chai.request(app)
       .get('/api/v1/parties/1')
@@ -196,7 +196,7 @@ describe('Edit a party name', () => {
   });
 });
 
-describe('Delete a party', () => {
+describe('DELETE A PARTY', () => {
   it('should respond with a the deleted party and a message', (done) => {
     chai.request(app)
       .delete('/api/v1/parties/3')
@@ -250,7 +250,7 @@ describe('Delete a party', () => {
   });
 });
 
-describe('Create political party', () => {
+describe('CREATE A POLITICAL PARTY', () => {
   it('should respond with the created party', (done) => {
     chai.request(app)
       .post('/api/v1/parties')

--- a/test/vote.test.js
+++ b/test/vote.test.js
@@ -29,8 +29,8 @@ describe('VOTE', () => {
       .post('/api/v1/votes')
       .set('Authorization', userToken)
       .send({
-        candidate: '1',
-        office: '1',
+        candidate: 1,
+        office: 1,
       })
       .end((err, res) => {
         expect(res).to.have.status(201);
@@ -42,45 +42,14 @@ describe('VOTE', () => {
       });
   });
 
-  it('should not vote candidate: no candidate specified', (done) => {
-    chai.request(app)
-      .post('/api/v1/votes')
-      .set('Authorization', userToken)
-      .send({
-        candidate: ' ',
-        office: '1',
-      })
-      .end((err, res) => {
-        expect(res).to.have.status(400);
-        expect(res.body.status).to.equal(400);
-        expect(res.body.error).to.equal('candidate must be present');
-        done();
-      });
-  });
-
-  it('should not vote candidate: no office specified', (done) => {
-    chai.request(app)
-      .post('/api/v1/votes')
-      .set('Authorization', userToken)
-      .send({
-        candidate: '1',
-        office: ' ',
-      })
-      .end((err, res) => {
-        expect(res).to.have.status(400);
-        expect(res.body.status).to.equal(400);
-        expect(res.body.error).to.equal('office must be present');
-        done();
-      });
-  });
 
   it('should not vote candidate: no such candidates', (done) => {
     chai.request(app)
       .post('/api/v1/votes')
       .set('Authorization', userToken)
       .send({
-        candidate: '0',
-        office: '1',
+        candidate: 1000,
+        office: 1,
       })
       .end((err, res) => {
         expect(res).to.have.status(404);
@@ -95,8 +64,8 @@ describe('VOTE', () => {
       .post('/api/v1/votes')
       .set('Authorization', userToken)
       .send({
-        candidate: '1',
-        office: '0',
+        candidate: 1,
+        office: 1000,
       })
       .end((err, res) => {
         expect(res).to.have.status(404);
@@ -106,13 +75,59 @@ describe('VOTE', () => {
       });
   });
 
-  it('should not vote candidate: candidate alredy voted', (done) => {
+  it('should not vote candidate: body is string', (done) => {
     chai.request(app)
       .post('/api/v1/votes')
       .set('Authorization', userToken)
       .send({
         candidate: '1',
-        office: '1',
+        office: '0',
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error[0]).to.have.property('error');
+        done();
+      });
+  });
+
+  it('should not vote candidate: no candidate', (done) => {
+    chai.request(app)
+      .post('/api/v1/votes')
+      .set('Authorization', userToken)
+      .send({
+        office: 0,
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error).to.have.equal('candidate must be present');
+        done();
+      });
+  });
+
+  it('should not vote candidate: no office', (done) => {
+    chai.request(app)
+      .post('/api/v1/votes')
+      .set('Authorization', userToken)
+      .send({
+        candidate: 1,
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error).to.have.equal('office must be present');
+        done();
+      });
+  });
+
+  it('should not vote candidate: candidate alredy voted', (done) => {
+    chai.request(app)
+      .post('/api/v1/votes')
+      .set('Authorization', userToken)
+      .send({
+        candidate: 1,
+        office: 1,
       })
       .end((err, res) => {
         expect(res).to.have.status(409);


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a bug on the data types inputed.

#### Description of Task to be completed?
- When sending an value, if they are integers then integers should be sent and not strings but if they are strings, strings should be sent and not integers

#### How should this be manually tested?
- follow instruction on `Readme`  to setup
- check out to branch `git checkout bg-input-data-type-163648726`
- setup environment variables from `example.env`
- set up `PostgreSql`
- `npm run test` to test
- using postman test `localhost:3000/api/v1/office/<user-id>/register` with office and party as integers

#### What are the relevant pivotal tracker stories?
[#163648726](https://www.pivotaltracker.com/story/show/163648726)

#### Screenshots

- bug:
![send string](https://user-images.githubusercontent.com/32283335/52121386-c2780d00-261f-11e9-9035-3ae270c3b029.PNG)

-fix:
![send number](https://user-images.githubusercontent.com/32283335/52121396-c99f1b00-261f-11e9-8a7a-7d5dc61fc595.PNG)


